### PR TITLE
Lock pg version to < 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '2.2.3'
 
 gem 'rails', '~> 4.2.7.1'
-gem 'pg'
+gem 'pg', '~> 0.18'
 gem 'bootstrap-sass'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
-    pg (1.0.0)
+    pg (0.21.0)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -199,7 +199,7 @@ DEPENDENCIES
   fastly-rails (~> 0.4.0)
   jbuilder (~> 2.0)
   jquery-rails
-  pg
+  pg (~> 0.18)
   pry-rails
   rails (~> 4.2.7.1)
   rails_12factor


### PR DESCRIPTION
The latest version of the pg gem is not supported by the version of rails currently in use in this app. The pg gem should be locked to a compatible version. 

See: https://github.com/rails/rails/pull/31671