### PR TITLE
Fix ruby-2.7.0 error by specifying stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,5 +5,6 @@
     "scripts": {
         "postdeploy": "bundle exec rake db:migrate"
     },
-    "generator": "https://www.expeditedssl.com/heroku-button-maker"
+    "generator": "https://www.expeditedssl.com/heroku-button-maker",
+    "stack": "heroku-18"
 }


### PR DESCRIPTION
Still getting an error from Heroku:

```
The Ruby version you are trying to install does not exist on this stack.
 !     
 !     You are trying to install ruby-2.7.0 on heroku-20.
 !     
 !     Ruby ruby-2.7.0 is present on the following stacks:
 !     
 !     - cedar-14
 !     - heroku-16
 !     - heroku-18
```

Using a different stack, `heroku-18`, to resolve.